### PR TITLE
Added Parishes and dependencies of Antigua and Barbuda in aab JSON

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -9,7 +9,7 @@
     { "name": "Angola", "code": "AO" },
     { "name": "Anguilla", "code": "AI" },
     { "name": "Antarctica", "code": "AQ" },
-    { "name": "Antigua and Barbuda", "code": "AG" },
+    { "name": "Antigua and Barbuda", "code": "AAB" },
     { "name": "Argentina", "code": "AR" },
     { "name": "Armenia", "code": "AM" },
     { "name": "Aruba", "code": "AW" },

--- a/data/countries/aab.json
+++ b/data/countries/aab.json
@@ -1,7 +1,7 @@
 {
         "country":"Antigua and Barbuda",
         "capital":"Saint John's",
-        "currency":"Eastern Caribbean dollar",
+        "currency":"Eastern Caribbean Dollar",
         "states":[
             {
                 "name":"Saint George",


### PR DESCRIPTION
Issue #141 : Added States (Parishes and dependencies of Antigua and Barbuda) to the aab.json and changed the country code from "AG" to "AAB"